### PR TITLE
Align default revision with Android version

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,19 @@
+# Download Kernel source
+ Refer to https://source.android.com/setup/build/building-kernels
+
+ Make separate kernel directory apart from Android source.
+
+  $ cd <kernel directory>
+  $ repo init -u https://github.com/android-rpi/kernel_manifest -b arpi-5.10
+  $ repo sync
+ 
+# Build Kernel
+  $ build/build.sh
+
+  Output files are under out/arpi-5.10/dist/
+    Image.gz
+    bcm2711-rpi-*.dtb
+    vc4-kms-v3d-pi4.dtbo
+
+# Build Android for Raspberry Pi 4
+ https://github.com/android-rpi/device_arpi_rpi4

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,6 @@
   <project path="kernel/tests" name="kernel/tests" />
   <project path="kernel/configs" name="kernel/configs" revision="master" />
   <project path="common-modules/virtual-device" name="kernel/common-modules/virtual-device" revision="android12-5.10" />
-  <project path="prebuilts/gas/linux-x86" name="platform/prebuilts/gas/linux-x86" clone-depth="1" />
   <project path="prebuilts-master/clang/host/linux-x86" name="platform/prebuilts/clang/host/linux-x86" clone-depth="1" />
   <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" clone-depth="1" />
   <project path="prebuilts/boot-artifacts" name="platform/prebuilts/boot-artifacts" />

--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote  name="aosp" fetch=".." review="https://android-review.googlesource.com/" />
+  <remote  name="aosp" fetch="https://android.googlesource.com" review="https://android-review.googlesource.com/" />
   <default revision="master" remote="aosp" sync-j="4" />
 
   <superproject name="kernel/superproject" remote="aosp"/>
@@ -20,4 +20,10 @@
   <project path="prebuilts/build-tools" name="platform/prebuilts/build-tools" clone-depth="1" />
   <project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" />
   <project path="tools/mkbootimg" name="platform/system/tools/mkbootimg" />
+
+  <remote  name="arpi" fetch="."/>
+  <remove-project name="kernel/common"/>
+  <project path="common" name="kernel_arpi" revision="arpi-5.10" remote="arpi">
+      <linkfile src="build.config.arpi" dest="build.config"/>
+  </project>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -3,6 +3,8 @@
   <remote  name="aosp" fetch=".." review="https://android-review.googlesource.com/" />
   <default revision="master" remote="aosp" sync-j="4" />
 
+  <superproject name="kernel/superproject" remote="aosp"/>
+
   <project path="build" name="kernel/build" />
   <project path="hikey-modules" name="kernel/hikey-modules" revision="android12-5.10" />
   <project path="common" name="kernel/common" revision="android12-5.10" />

--- a/default.xml
+++ b/default.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote  name="aosp" fetch="https://android.googlesource.com" review="https://android-review.googlesource.com/" />
-  <default revision="master" remote="aosp" sync-j="4" />
+  <default revision="master-kernel-build-2021" remote="aosp" sync-j="4" />
 
   <superproject name="kernel/superproject" remote="aosp"/>
 
   <project path="build" name="kernel/build" />
   <project path="hikey-modules" name="kernel/hikey-modules" revision="android12-5.10" />
   <project path="common" name="kernel/common" revision="android12-5.10" />
-  <project path="kernel/common-patches" name="kernel/common-patches" >
+  <project path="kernel/common-patches" name="kernel/common-patches" revision="master">
       <linkfile src="android-mainline" dest="common/patches" />
   </project>
   <project path="kernel/tests" name="kernel/tests" />
@@ -19,7 +19,7 @@
   <project path="prebuilts/boot-artifacts" name="platform/prebuilts/boot-artifacts" />
   <project path="prebuilts/build-tools" name="platform/prebuilts/build-tools" clone-depth="1" />
   <project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" />
-  <project path="tools/mkbootimg" name="platform/system/tools/mkbootimg" />
+  <project path="tools/mkbootimg" name="platform/system/tools/mkbootimg" revision="master" />
 
   <remote  name="arpi" fetch="."/>
   <remove-project name="kernel/common"/>


### PR DESCRIPTION
Certain projects may move forward on their master branch breaking
compatibility with other Android-version-specific projects. This happend
e.g. with the 'kernel/build' project where on the master branch certain
path' and locations have changed.

Thus we have to pin the default revision to the Android and kernel
version we want to build for. This also fixes issue #7.

Change-Id: Icf22094caf3521d506acaeb9a3c3f9265d1a877f